### PR TITLE
Implement close/open sidebar

### DIFF
--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/DashboardComponents/DashboardNavbar.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/DashboardComponents/DashboardNavbar.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import { Box, Typography } from '@material-ui/core';
+import SimpleMenu from './DropdownMenu';
+
+export default function DashboardNavbar() {
+    return (
+        <div>
+            <CssBaseline />
+            <AppBar position="fixed">
+                <Toolbar>
+                    <Box display="flex" flexGrow={1}>
+                        <Typography variant="h4" noWrap>
+                            Ethisim Dashboard
+                        </Typography>
+                    </Box>
+                    <SimpleMenu />
+                </Toolbar>
+            </AppBar>
+        </div>
+    );
+}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/DashboardComponents/DropdownMenu.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/DashboardComponents/DropdownMenu.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import IconButton from '@material-ui/core/IconButton';
+import { Link } from 'react-router-dom';
+import shemptylogo from '../EditorComponents/ConversationEditorComponents/StakeHoldersComponent/shemptylogo.png';
+
+export default function SimpleMenu() {
+    const [anchorEl, setAnchorEl] = React.useState(null);
+
+    const handleClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <div>
+            <IconButton
+                aria-controls="simple-menu"
+                aria-haspopup="true"
+                onClick={handleClick}
+            >
+                <img src={shemptylogo} height={50} width={50} alt=""></img>
+            </IconButton>
+            <Menu
+                id="simple-menu"
+                anchorEl={anchorEl}
+                keepMounted
+                open={Boolean(anchorEl)}
+                onClose={handleClose}
+            >
+                <MenuItem
+                    onClick={handleClose}
+                    component={Link}
+                    to={{
+                        pathname: '/home',
+                    }}
+                >
+                    Logout
+                </MenuItem>
+                <MenuItem onClick={handleClose}>Settings</MenuItem>
+                <MenuItem onClick={handleClose}>Help</MenuItem>
+            </Menu>
+        </div>
+    );
+}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/dashboard.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/dashboard.js
@@ -8,10 +8,11 @@ import {
     mockUnfinishedScenario,
     mockFinishedScenario,
 } from '../shared/mockScenarioData';
+import DashboardNavbar from '../components/DashboardComponents/DashboardNavbar';
 
 const useStyles = makeStyles((theme) => ({
     container: {
-        marginTop: theme.spacing(1),
+        marginTop: theme.spacing(6),
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
@@ -57,31 +58,38 @@ export default function Dashboard() {
     ));
 
     return (
-        <Container className={classes.container} component="main" maxWidth="lg">
-            <Typography variant="h4">Unfinished Scenarios</Typography>
-            <Grid
-                container
-                spacing={2}
-                direction="row"
-                justify="flex-start"
-                alignItems="stretch"
+        <div className={classes.container}>
+            <DashboardNavbar />
+            <Container
+                className={classes.container}
+                component="main"
+                maxWidth="lg"
             >
-                {unfinishedScenarios}
-                <AddNewScenarioCard />
-            </Grid>
-            <Typography variant="h4">Finished Scenarios</Typography>
-            <Grid
-                container
-                spacing={2}
-                direction="row"
-                justify="flex-start"
-                alignItems="stretch"
-            >
-                {finishedScenarios}
-            </Grid>
-            <Box className={classes.copyright}>
-                <Copyright />
-            </Box>
-        </Container>
+                <Typography variant="h4">Unfinished Scenarios</Typography>
+                <Grid
+                    container
+                    spacing={2}
+                    direction="row"
+                    justify="flex-start"
+                    alignItems="stretch"
+                >
+                    {unfinishedScenarios}
+                    <AddNewScenarioCard />
+                </Grid>
+                <Typography variant="h4">Finished Scenarios</Typography>
+                <Grid
+                    container
+                    spacing={2}
+                    direction="row"
+                    justify="flex-start"
+                    alignItems="stretch"
+                >
+                    {finishedScenarios}
+                </Grid>
+                <Box className={classes.copyright}>
+                    <Copyright />
+                </Box>
+            </Container>
+        </div>
     );
 }

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
@@ -1,6 +1,16 @@
 import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Drawer, Button, Typography } from '@material-ui/core';
+import Container from '@material-ui/core/Container';
+import clsx from 'clsx';
+import { useTheme } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import IconButton from '@material-ui/core/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import Logistics from '../components/EditorComponents/LogisticsPageComponents/Logistics';
 import Generic from '../components/EditorComponents/GenericPageComponents/Generic';
 import ConfigureIssues from '../components/EditorComponents/ConfigureIssuesComponents/ConfigureIssues';
@@ -17,6 +27,20 @@ const drawerWidth = 240;
 const useStyles = makeStyles((theme) => ({
     root: {
         display: 'flex',
+    },
+    appBar: {
+        transition: theme.transitions.create(['margin', 'width'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+    },
+    appBarShift: {
+        width: `calc(100% - ${drawerWidth}px)`,
+        marginLeft: drawerWidth,
+        transition: theme.transitions.create(['margin', 'width'], {
+            easing: theme.transitions.easing.easeOut,
+            duration: theme.transitions.duration.enteringScreen,
+        }),
     },
     menuButton: {
         marginRight: theme.spacing(2),
@@ -38,7 +62,7 @@ const useStyles = makeStyles((theme) => ({
     container: {
         marginTop: theme.spacing(1),
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: 'row',
         alignItems: 'center',
     },
     title: {
@@ -53,6 +77,30 @@ const useStyles = makeStyles((theme) => ({
         textTransform: 'unset',
         border: 'solid 3px',
         borderColor: theme.palette.primary.light,
+    },
+    drawerHeader: {
+        display: 'flex',
+        alignItems: 'center',
+        padding: theme.spacing(0, 1),
+        // necessary for content to be below app bar
+        ...theme.mixins.toolbar,
+        justifyContent: 'flex-end',
+    },
+    content: {
+        flexGrow: 1,
+        padding: theme.spacing(3),
+        transition: theme.transitions.create('margin', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        marginLeft: -drawerWidth,
+    },
+    contentShift: {
+        transition: theme.transitions.create('margin', {
+            easing: theme.transitions.easing.easeOut,
+            duration: theme.transitions.duration.enteringScreen,
+        }),
+        marginLeft: 0,
     },
 }));
 
@@ -92,6 +140,15 @@ var startList = [
 
 export default function Editor(props) {
     const classes = useStyles();
+    const theme = useTheme();
+    const [open, setOpen] = React.useState(false);
+    const handleDrawerOpen = () => {
+        setOpen(true);
+    };
+    const handleDrawerClose = () => {
+        setOpen(false);
+    };
+
     const [openPopup, setOpenPopup] = useState(false);
     //Fake fetch of scenarioData with components
     let fetchedComponents = mockUnfinishedScenarioData.components;
@@ -153,12 +210,22 @@ export default function Editor(props) {
             <div>
                 <Drawer
                     className={classes.drawer}
-                    variant="permanent"
+                    variant="persistent"
+                    anchor="left"
+                    open={open}
                     classes={{
                         paper: classes.drawerPaper,
                     }}
-                    anchor="left"
                 >
+                    <IconButton onClick={handleDrawerClose}>
+                        {theme.direction === 'ltr' ? (
+                            <ChevronLeftIcon />
+                        ) : (
+                            <ChevronRightIcon />
+                        )}
+                        Hide Menu
+                    </IconButton>
+
                     <NavSideBarList
                         onClick={onClick}
                         deleteByID={deleteByID}
@@ -185,9 +252,43 @@ export default function Editor(props) {
     }
 
     return (
-        <div className={classes.root}>
+        <div className={classes.container}>
+            <CssBaseline />
+            <AppBar
+                position="fixed"
+                className={clsx(classes.appBar, {
+                    [classes.appBarShift]: open,
+                })}
+            >
+                <Toolbar>
+                    <IconButton
+                        color="inherit"
+                        aria-label="open drawer"
+                        onClick={handleDrawerOpen}
+                        edge="start"
+                        className={clsx(
+                            classes.menuButton,
+                            open && classes.hide
+                        )}
+                    >
+                        <MenuIcon />
+                    </IconButton>
+                    <Typography variant="h6" noWrap>
+                        Ethisim Scenario Editor
+                    </Typography>
+                </Toolbar>
+            </AppBar>
+
             <Sidebar />
-            <main className={classes.content}>{scenarioComponent}</main>
+
+            <main
+                className={clsx(classes.content, {
+                    [classes.contentShift]: open,
+                })}
+            >
+                <div className={classes.drawerHeader} />
+                {scenarioComponent}
+            </main>
         </div>
     );
 }

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
@@ -1,13 +1,6 @@
 import React, { useState } from 'react';
 import { makeStyles, useTheme, withStyles } from '@material-ui/core/styles';
-import {
-    Drawer,
-    Box,
-    Grid,
-    Container,
-    Button,
-    Typography,
-} from '@material-ui/core';
+import { Drawer, Box, Button, Typography } from '@material-ui/core';
 import clsx from 'clsx';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
@@ -313,7 +306,7 @@ export default function Editor(props) {
                         }}
                         className={classes.exitButton}
                     >
-                        <WhiteTextTypography>
+                        <WhiteTextTypography noWrap>
                             Return to Dashboard
                         </WhiteTextTypography>
                     </Button>

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Drawer, Button, Typography } from '@material-ui/core';
+import { makeStyles, useTheme, withStyles } from '@material-ui/core/styles';
+import {
+    Drawer,
+    Box,
+    Grid,
+    Container,
+    Button,
+    Typography,
+} from '@material-ui/core';
 import clsx from 'clsx';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
@@ -19,6 +26,7 @@ import AddNewSimulationScenarioPageDialog from '../components//EditorComponents/
 import NavSideBarList from '../components/ConfigurationSideBarComponents/NavSideBarList';
 import AddIcon from '@material-ui/icons/Add';
 import { mockUnfinishedScenarioData } from '../shared/mockScenarioData';
+import { Link } from 'react-router-dom';
 
 const drawerWidth = 240;
 
@@ -39,6 +47,12 @@ const useStyles = makeStyles((theme) => ({
             easing: theme.transitions.easing.easeOut,
             duration: theme.transitions.duration.enteringScreen,
         }),
+    },
+    exitButton: {
+        margin: theme.spacing(2),
+        borderStyle: 'solid',
+        borderColor: 'white',
+        border: 2,
     },
     menuButton: {
         marginRight: theme.spacing(2),
@@ -147,6 +161,18 @@ export default function Editor(props) {
         setOpen(false);
     };
 
+    const WhiteTextTypography = withStyles({
+        root: {
+            color: '#FFFFFF',
+        },
+    })(Typography);
+
+    const BlackTextTypography = withStyles({
+        root: {
+            color: '#000000',
+        },
+    })(Typography);
+
     const [openPopup, setOpenPopup] = useState(false);
     //Fake fetch of scenarioData with components
     let fetchedComponents = mockUnfinishedScenarioData.components;
@@ -221,7 +247,9 @@ export default function Editor(props) {
                         ) : (
                             <ChevronRightIcon />
                         )}
-                        Hide Menu
+                        <BlackTextTypography variant="h6">
+                            Hide Menu
+                        </BlackTextTypography>
                     </IconButton>
 
                     <NavSideBarList
@@ -259,21 +287,36 @@ export default function Editor(props) {
                 })}
             >
                 <Toolbar>
-                    <IconButton
-                        color="inherit"
-                        aria-label="open drawer"
-                        onClick={handleDrawerOpen}
-                        edge="start"
-                        className={clsx(
-                            classes.menuButton,
-                            open && classes.hide
-                        )}
+                    <Box display="flex" flexGrow={1}>
+                        <IconButton
+                            color="inherit"
+                            aria-label="open drawer"
+                            onClick={handleDrawerOpen}
+                            edge="start"
+                            className={clsx(
+                                classes.menuButton,
+                                open && classes.hide
+                            )}
+                        >
+                            <MenuIcon />
+                        </IconButton>
+
+                        <Typography variant="h4" noWrap>
+                            Ethisim Scenario Editor
+                        </Typography>
+                    </Box>
+
+                    <Button
+                        component={Link}
+                        to={{
+                            pathname: '/dashboard',
+                        }}
+                        className={classes.exitButton}
                     >
-                        <MenuIcon />
-                    </IconButton>
-                    <Typography variant="h6" noWrap>
-                        Ethisim Scenario Editor
-                    </Typography>
+                        <WhiteTextTypography>
+                            Return to Dashboard
+                        </WhiteTextTypography>
+                    </Button>
                 </Toolbar>
             </AppBar>
 

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { Drawer, Button, Typography } from '@material-ui/core';
-import Container from '@material-ui/core/Container';
 import clsx from 'clsx';
-import { useTheme } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -86,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
         ...theme.mixins.toolbar,
         justifyContent: 'flex-end',
     },
-    content: {
+    content1: {
         flexGrow: 1,
         padding: theme.spacing(3),
         transition: theme.transitions.create('margin', {
@@ -282,7 +280,7 @@ export default function Editor(props) {
             <Sidebar />
 
             <main
-                className={clsx(classes.content, {
+                className={clsx(classes.content1, {
                     [classes.contentShift]: open,
                 })}
             >


### PR DESCRIPTION
Took the Persistent Drawer Component from Material-UI and integrated it into our existing code to allow for the sidebar to be open or closed. Also added an AppBar to the top of the scenarioEditor, which is the red bar seen in the GIF.  Fixed two compiler warnings. 

![PersistentDrawer2](https://user-images.githubusercontent.com/54215233/98483117-e6dd2200-21d3-11eb-841d-0f2d467b7b83.gif)

