### PR TITLE
Various Fixes

### DIFF
--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ActionPageComponents/Action.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ActionPageComponents/Action.js
@@ -3,8 +3,6 @@ import { Button, TextField, Typography, Container } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import Body from '../GeneralPageComponents/Body';
 import Title from '../GeneralPageComponents/Title';
-import VersionControl from '../../VersionControl';
-import { mockActionHistory } from '../../../shared/mockScenarioData';
 import PropTypes from 'prop-types';
 import universalPost from '../../../universalHTTPRequests/post.js';
 import universalDelete from '../../../universalHTTPRequests/delete.js';
@@ -262,14 +260,6 @@ export default function Action(props) {
             <Typography align="center" variant="h2">
                 Action Component
             </Typography>
-            <VersionControl
-                history={mockActionHistory.history}
-                type={mockActionHistory.type}
-                setTitle={setTitle}
-                setBody={setBodyText}
-                setOption1={setOption1}
-                setOption2={setOption2}
-            />
             <Title
                 title={title}
                 setTitle={setTitle}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ActionPageComponents/Action.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ActionPageComponents/Action.js
@@ -13,6 +13,7 @@ import LoadingSpinner from '../../LoadingSpinner';
 Action.propTypes = {
     scenarioComponents: PropTypes.any,
     setScenarioComponents: PropTypes.any,
+    setCurrentPageID: PropTypes.any,
     page_id: PropTypes.any,
     page_type: PropTypes.any,
     page_title: PropTypes.any,
@@ -64,6 +65,7 @@ export default function Action(props) {
     const {
         scenarioComponents,
         setScenarioComponents,
+        setCurrentPageID,
         page_id,
         page_type,
         page_title,
@@ -127,6 +129,7 @@ export default function Action(props) {
             component.id = resp.data.PAGE;
             component.title = title;
             setPageID(resp.data.PAGE);
+            setCurrentPageID(resp.data.PAGE);
             setScenarioComponents(newScenarioComponents);
             setSuccessBannerFade(true);
             setSuccessBannerMessage('Successfully saved page!');

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ActionPageComponents/Action.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ActionPageComponents/Action.js
@@ -203,6 +203,11 @@ export default function Action(props) {
                 onSuccess,
                 postReqBody
             );
+        } else {
+            setErrorBannerFade(true);
+            setErrorBannerMessage(
+                'There are currently errors within your page. Please fix all errors in order to save.'
+            );
         }
     }
 

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ConfigureIssuesComponents/ConfigureIssues.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ConfigureIssuesComponents/ConfigureIssues.js
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Typography, Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import EntryFields from './IssueEntryFieldList';
-import VersionControl from '../../VersionControl';
-import { mockIssuesHistory } from '../../../shared/mockScenarioData';
 import get from '../../../universalHTTPRequests/get';
 import LoadingSpinner from '../../LoadingSpinner';
 import RefreshIcon from '@material-ui/icons/Refresh';
@@ -11,7 +9,7 @@ import ErrorIcon from '@material-ui/icons/Error';
 import PropTypes from 'prop-types';
 
 //Need scenarioID
-const endpointGET = '/api/issues/?SCENARIO_ID=';
+const endpointGET = '/api/issues/?SCENARIO=';
 
 const useStyles = makeStyles((theme) => ({
     issue: {
@@ -89,14 +87,6 @@ export default function ConfigureIssues({ scenario_ID }) {
             <Typography align="center" variant="h2">
                 Configure Ethical Issues
             </Typography>
-            <div className={classes.spacing}>
-                <VersionControl
-                    className={classes.spacing}
-                    history={mockIssuesHistory.history}
-                    type={'Issues'}
-                    setIssueEntryFieldList={setIssueEntryFieldList}
-                />
-            </div>
             <div className={classes.spacing}>
                 <Button variant="contained" color="primary" onClick={getData}>
                     <RefreshIcon className={classes.iconRefreshSmall} />

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ConversationEditorComponents/ConversationEditor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ConversationEditorComponents/ConversationEditor.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@material-ui/core';
 import StakeHolderFields from './StakeHoldersComponent/stakeHolders';
-import VersionControl from '../../VersionControl';
-import { mockConversationEditorHistory } from '../../../shared/mockScenarioData';
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
@@ -11,9 +9,6 @@ const useStyles = makeStyles((theme) => ({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-    },
-    versionControl: {
-        margin: theme.spacing(2),
     },
     saveButton: {
         margin: theme.spacing(2),
@@ -28,11 +23,6 @@ export default function ConversationEditor() {
 
     return (
         <div>
-            <VersionControl
-                history={mockConversationEditorHistory.history}
-                type={'Conversation Editor'}
-                setStakeHolders={setStakeHolders}
-            />
             <StakeHolderFields
                 stakeHolders={stakeHolders}
                 setStakeHolders={setStakeHolders}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/FlowDiagramComponents/FlowDiagram.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/FlowDiagramComponents/FlowDiagram.js
@@ -102,6 +102,7 @@ export default function FlowDiagram({ scenario_ID }) {
 
     const [elements, setElements] = useState([]);
     const [unsaved, setUnsaved] = useState(false);
+    const [errorText, setErrorText] = useState('');
 
     function positionElements(elements) {
         let introductionElement = elements.filter((componentData) => {
@@ -159,6 +160,10 @@ export default function FlowDiagram({ scenario_ID }) {
         elements.forEach((currentElement) => {
             //TODO
             if (currentElement.type === 'actionNode') {
+                if (!currentElement.ACTION[0]) {
+                    // eslint-disable-next-line
+                    throw 'Action incomplete';
+                }
                 //Only 2 action options
                 if (currentElement.ACTION[0].RESULT_PAGE) {
                     elements = addEdge(
@@ -197,7 +202,16 @@ export default function FlowDiagram({ scenario_ID }) {
         function onSuccess(resp) {
             setElements(addEdges(positionElements(resp.data)));
         }
-        get(setFetchedElements, endpointGET + scenarioID, null, onSuccess);
+        function onError(resp) {
+            if (resp === 'Action incomplete') {
+                setErrorText(
+                    'You have at least one Action page that is incomplete (i.e. without options). You must complete all action pages before you can access the Flow Diagram.'
+                );
+            } else {
+                setErrorText('Unable to fetch Flow Diagram! Please try again.');
+            }
+        }
+        get(setFetchedElements, endpointGET + scenarioID, onError, onSuccess);
     };
 
     useEffect(getData, []);
@@ -472,8 +486,8 @@ export default function FlowDiagram({ scenario_ID }) {
             <div className={classes.errorContainer}>
                 <div className={classes.container}>
                     <ErrorIcon className={classes.iconError} />
-                    <Typography align="center" variant="h3">
-                        Error in fetching Flow Diagram.
+                    <Typography align="center" variant="h5">
+                        {errorText}
                     </Typography>
                     <Button
                         variant="contained"

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Generic.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Generic.js
@@ -143,6 +143,11 @@ export default function Generic(props) {
                 onSuccess,
                 postReqBody
             );
+        } else {
+            setErrorBannerFade(true);
+            setErrorBannerMessage(
+                'There are currently errors within your page. Please fix all errors in order to save.'
+            );
         }
     }
 

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Generic.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Generic.js
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
 Generic.propTypes = {
     scenarioComponents: PropTypes.any,
     setScenarioComponents: PropTypes.any,
+    setCurrentPageID: PropTypes.any,
     page_id: PropTypes.any,
     page_type: PropTypes.any,
     page_title: PropTypes.any,
@@ -43,6 +44,7 @@ export default function Generic(props) {
     const {
         scenarioComponents,
         setScenarioComponents,
+        setCurrentPageID,
         page_id,
         page_type,
         page_title,
@@ -98,6 +100,7 @@ export default function Generic(props) {
             component.id = resp.data.PAGE;
             component.title = title;
             setPageID(resp.data.PAGE);
+            setCurrentPageID(resp.data.PAGE);
             setScenarioComponents(newScenarioComponents);
             setSuccessBannerFade(true);
             setSuccessBannerMessage('Successfully saved page!');

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Generic.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Generic.js
@@ -2,9 +2,6 @@ import React, { useState, useEffect } from 'react';
 import Body from '../GeneralPageComponents/Body';
 import Title from '../GeneralPageComponents/Title';
 import { Typography, Container, Button } from '@material-ui/core';
-import VersionControl from '../../VersionControl';
-//import InformationItemList from './InformationItemList';
-import { mockGenericHistory } from '../../../shared/mockScenarioData';
 import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import universalPost from '../../../universalHTTPRequests/post.js';
@@ -195,12 +192,6 @@ export default function Generic(props) {
             <Typography align="center" variant="h2">
                 Generic Component
             </Typography>
-            <VersionControl
-                history={mockGenericHistory.history}
-                type={mockGenericHistory.type}
-                setTitle={setTitle}
-                setBody={setBodyText}
-            />
             <Title
                 title={title}
                 setTitle={setTitle}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Introduction.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Introduction.js
@@ -2,9 +2,6 @@ import React, { useState, useEffect } from 'react';
 import Body from '../GeneralPageComponents/Body';
 import Title from '../GeneralPageComponents/Title';
 import { Typography, Container, Button } from '@material-ui/core';
-import VersionControl from '../../VersionControl';
-//import InformationItemList from './InformationItemList';
-import { mockGenericHistory } from '../../../shared/mockScenarioData';
 import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import universalPost from '../../../universalHTTPRequests/post.js';
@@ -195,12 +192,6 @@ export default function Introduction(props) {
             <Typography align="center" variant="h2">
                 Generic Component
             </Typography>
-            <VersionControl
-                history={mockGenericHistory.history}
-                type={mockGenericHistory.type}
-                setTitle={setTitle}
-                setBody={setBodyText}
-            />
             <Title
                 title={title}
                 setTitle={setTitle}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Introduction.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Introduction.js
@@ -143,6 +143,11 @@ export default function Introduction(props) {
                 onSuccess,
                 postReqBody
             );
+        } else {
+            setErrorBannerFade(true);
+            setErrorBannerMessage(
+                'There are currently errors within your page. Please fix all errors in order to save.'
+            );
         }
     }
 

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Introduction.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/GenericPageComponents/Introduction.js
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
 Introduction.propTypes = {
     scenarioComponents: PropTypes.any,
     setScenarioComponents: PropTypes.any,
+    setCurrentPageID: PropTypes.any,
     page_id: PropTypes.any,
     page_type: PropTypes.any,
     page_title: PropTypes.any,
@@ -43,6 +44,7 @@ export default function Introduction(props) {
     const {
         scenarioComponents,
         setScenarioComponents,
+        setCurrentPageID,
         page_id,
         page_type,
         page_title,
@@ -98,6 +100,7 @@ export default function Introduction(props) {
             component.id = resp.data.PAGE;
             component.title = title;
             setPageID(resp.data.PAGE);
+            setCurrentPageID(resp.data.PAGE);
             setScenarioComponents(newScenarioComponents);
             setSuccessBannerFade(true);
             setSuccessBannerMessage('Successfully saved page!');
@@ -195,7 +198,7 @@ export default function Introduction(props) {
                 />
             </div>
             <Typography align="center" variant="h2">
-                Generic Component
+                Introduction Page
             </Typography>
             <Title
                 title={title}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/LogisticsPageComponents/Logistics.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/LogisticsPageComponents/Logistics.js
@@ -338,6 +338,11 @@ export default function Logistics({ scenario_ID }) {
                 onSuccessLogistic,
                 NewScenario
             );
+        } else {
+            setErrorBannerFade(true);
+            setErrorBannerMessage(
+                'There are currently errors within your page. Please fix all errors in order to save.'
+            );
         }
     };
 

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/LogisticsPageComponents/Logistics.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/LogisticsPageComponents/Logistics.js
@@ -527,12 +527,6 @@ export default function Logistics({ scenario_ID }) {
                         noValidate
                         autoComplete="off"
                     >
-                        <Button variant="contained">
-                            View Student Responses
-                        </Button>
-                        <Button variant="contained" color="primary">
-                            View Version History
-                        </Button>
                         <Button
                             variant="contained"
                             color="primary"

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ReflectionPageComponents/Reflection.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ReflectionPageComponents/Reflection.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import Body from '../GeneralPageComponents/Body';
 import Title from '../GeneralPageComponents/Title';
-import VersionControl from '../../VersionControl';
 import { Typography, Container, Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import QuestionFields from './QuestionComponent/questions';
-import { mockReflectionHistory } from '../../../shared/mockScenarioData';
 import PropTypes from 'prop-types';
 import universalPost from '../../../universalHTTPRequests/post.js';
 import universalDelete from '../../../universalHTTPRequests/delete.js';
@@ -241,13 +239,6 @@ export default function Reflection(props) {
             <Typography align="center" variant="h2">
                 Reflection Component
             </Typography>
-            <VersionControl
-                history={mockReflectionHistory.history}
-                type={mockReflectionHistory.type}
-                setTitle={setTitle}
-                setBody={setBodyText}
-                setQuestions={setQuestions}
-            />
             <Title
                 title={title}
                 setTitle={setTitle}

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ReflectionPageComponents/Reflection.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ReflectionPageComponents/Reflection.js
@@ -14,6 +14,7 @@ import LoadingSpinner from '../../LoadingSpinner';
 Reflection.propTypes = {
     scenarioComponents: PropTypes.any,
     setScenarioComponents: PropTypes.any,
+    setCurrentPageID: PropTypes.any,
     page_id: PropTypes.any,
     page_type: PropTypes.any,
     page_title: PropTypes.any,
@@ -45,6 +46,7 @@ export default function Reflection(props) {
     const {
         scenarioComponents,
         setScenarioComponents,
+        setCurrentPageID,
         page_id,
         page_type,
         page_title,
@@ -111,6 +113,7 @@ export default function Reflection(props) {
             component.title = title;
 
             setPageID(resp.data.PAGE);
+            setCurrentPageID(resp.data.PAGE);
             setScenarioComponents(newScenarioComponents);
             setSuccessBannerFade(true);
             setSuccessBannerMessage('Successfully saved page!');

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ReflectionPageComponents/Reflection.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/components/EditorComponents/ReflectionPageComponents/Reflection.js
@@ -33,6 +33,12 @@ const useStyles = makeStyles((theme) => ({
         float: 'right',
         textTransform: 'unset',
     },
+    bannerContainer: {
+        marginTop: theme.spacing(1),
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+    },
 }));
 
 export default function Reflection(props) {
@@ -183,6 +189,11 @@ export default function Reflection(props) {
                 onSuccess,
                 postReqBody
             );
+        } else {
+            setErrorBannerFade(true);
+            setErrorBannerMessage(
+                'There are currently errors within your page. Please fix all errors in order to save.'
+            );
         }
     }
 
@@ -228,14 +239,16 @@ export default function Reflection(props) {
 
     return (
         <Container component="main">
-            <SuccessBanner
-                successMessage={successBannerMessage}
-                fade={successBannerFade}
-            />
-            <ErrorBanner
-                errorMessage={errorBannerMessage}
-                fade={errorBannerFade}
-            />
+            <div className={classes.bannerContainer}>
+                <SuccessBanner
+                    successMessage={successBannerMessage}
+                    fade={successBannerFade}
+                />
+                <ErrorBanner
+                    errorMessage={errorBannerMessage}
+                    fade={errorBannerFade}
+                />
+            </div>
             <Typography align="center" variant="h2">
                 Reflection Component
             </Typography>

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
@@ -251,7 +251,7 @@ export default function Editor(props) {
 
             for (let i = 0; i < pages.length; i++) {
                 //Already have component in initial components
-                if (pages[i].PAGE_TITLE === 'Stakeholder Conversations') {
+                if (pages[i].PAGE_TYPE === 'S') {
                     continue;
                 }
                 //Intro page is first page on sidebar
@@ -331,6 +331,7 @@ export default function Editor(props) {
                 p = {
                     scenarioComponents: scenarioComponentsArray,
                     setScenarioComponents: setScenarioComponents,
+                    setCurrentPageID: setCurrentPageID,
                     page_id: currPageInfo.PAGE,
                     page_type: currPageInfo.PAGE_TYPE,
                     page_title: currPageInfo.PAGE_TITLE,
@@ -348,6 +349,7 @@ export default function Editor(props) {
                 p = {
                     scenarioComponents: scenarioComponentsArray,
                     setScenarioComponents: setScenarioComponents,
+                    setCurrentPageID: setCurrentPageID,
                     page_id: currPageInfo.PAGE,
                     page_type: currPageInfo.PAGE_TYPE,
                     page_title: currPageInfo.PAGE_TITLE,
@@ -365,6 +367,7 @@ export default function Editor(props) {
                 p = {
                     scenarioComponents: scenarioComponentsArray,
                     setScenarioComponents: setScenarioComponents,
+                    setCurrentPageID: setCurrentPageID,
                     page_id: currPageInfo.PAGE,
                     page_type: currPageInfo.PAGE_TYPE,
                     page_title: currPageInfo.PAGE_TITLE,
@@ -393,6 +396,7 @@ export default function Editor(props) {
                 p = {
                     scenarioComponents: scenarioComponentsArray,
                     setScenarioComponents: setScenarioComponents,
+                    setCurrentPageID: setCurrentPageID,
                     page_id: currPageInfo.PAGE,
                     page_type: currPageInfo.PAGE_TYPE,
                     page_title: currPageInfo.PAGE_TITLE,

--- a/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
+++ b/Ghost_in_the_Shell/client_folder_react_app/ethisim/src/pages/editor.js
@@ -191,6 +191,7 @@ export default function Editor(props) {
     const [scenarioComponent, setScenarioComponent] = useState(null);
     const [showEditor, setShowEditor] = useState(false);
     const [addNewPageIndex, setAddNewPageIndex] = useState(null);
+    const [currentPageID, setCurrentPageID] = useState(-1);
 
     let handleLogisticsGet = function handleLogisticsGet() {
         let initialComponents = [
@@ -411,6 +412,7 @@ export default function Editor(props) {
             newScenarioComponents = newScenarioComponents.map((x) =>
                 x.id === resp.data.PAGE ? { ...x, component: c } : x
             );
+            setCurrentPageID(currPageInfo.PAGE);
             setScenarioComponents(newScenarioComponents);
             console.log(g_id);
             setScenarioComponent(c);
@@ -452,7 +454,7 @@ export default function Editor(props) {
     useEffect(handleLogisticsGet, [shouldFetch]);
 
     let onClick = (id, title, scenarioPages) => {
-        console.log(id);
+        setCurrentPageID(id);
         if (id !== -1 && id !== -2 && id !== -3 && id !== -4) {
             handlePageGet(setGetValues, id, scenarioPages);
         }
@@ -463,10 +465,13 @@ export default function Editor(props) {
 
     const deleteByID = (d_id) => {
         //If on page that is going to be deleted, redirect back to logistics page
+        console.log(d_id);
+        console.log(currentPageID);
         if (
-            scenarioComponents.filter((i) => i.id === d_id)[0].component ===
-            scenarioComponent
+            scenarioComponents.filter((i) => i.id === d_id)[0].id ===
+            currentPageID
         ) {
+            setCurrentPageID(-1);
             setScenarioComponent(scenarioComponents[0].component);
         }
         setScenarioComponents(scenarioComponents.filter((i) => i.id !== d_id));


### PR DESCRIPTION
-Flow Diagram warning
-Safer logic for deleting pages (If you delete the page you are currently editing, you get redirected to Logistics page, if you delete page you are not currently on, you stay on that page)
-Remove version history buttons from all pages + Logistics page (Also removed student responses button which is useless)
-Error banners will pop up if page is unable to save due to text errors such as blank title fields, blank option/action fields, blank reflection question fields, etc.

![F](https://user-images.githubusercontent.com/51762139/100767455-c9146e80-33c7-11eb-8613-6a8aa65ae79b.gif)
